### PR TITLE
feat: AWS receiver with SQS fanout

### DIFF
--- a/tf/.gitignore
+++ b/tf/.gitignore
@@ -1,0 +1,6 @@
+*.tfstate
+*.tfstate.*.backup
+*.tfstate.backup
+*.tfvars
+/.terraform
+/lambda.zip

--- a/tf/.terraform.lock.hcl
+++ b/tf/.terraform.lock.hcl
@@ -1,0 +1,43 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/archive" {
+  version = "2.4.2"
+  hashes = [
+    "h1:WfIjVbYA9s/uN2FwhGoiffT7CLFydy7MT1waFbt9YrY=",
+    "zh:08faed7c9f42d82bc3d406d0d9d4971e2d1c2d34eae268ad211b8aca57b7f758",
+    "zh:3564112ed2d097d7e0672378044a69b06642c326f6f1584d81c7cdd32ebf3a08",
+    "zh:53cd9afd223c15828c1916e68cb728d2be1cbccb9545568d6c2b122d0bac5102",
+    "zh:5ae4e41e3a1ce9d40b6458218a85bbde44f21723943982bca4a3b8bb7c103670",
+    "zh:5b65499218b315b96e95c5d3463ea6d7c66245b59461217c99eaa1611891cd2c",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:7f45b35a8330bebd184c2545a41782ff58240ed6ba947274d9881dd5da44b02e",
+    "zh:87e67891033214e55cfead1391d68e6a3bf37993b7607753237e82aa3250bb71",
+    "zh:de3590d14037ad81fc5cedf7cfa44614a92452d7b39676289b704a962050bc5e",
+    "zh:e7e6f2ea567f2dbb3baa81c6203be69f9cd6aeeb01204fd93e3cf181e099b610",
+    "zh:fd24d03c89a7702628c2e5a3c732c0dede56fa75a08da4a1efe17b5f881c88e2",
+    "zh:febf4b7b5f3ff2adff0573ef6361f09b6638105111644bdebc0e4f575373935f",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version = "5.34.0"
+  hashes = [
+    "h1:CUCoX4ax5hrP6BH4973oP+hgz8VR2GuNPQil3FYwEqQ=",
+    "zh:01bb20ae12b8c66f0cacec4f417a5d6741f018009f3a66077008e67cce127aa4",
+    "zh:3b0c9bdbbf846beef2c9573fc27898ceb71b69cf9d2f4b1dd2d0c2b539eab114",
+    "zh:5226ecb9c21c2f6fbf1d662ac82459ffcd4ad058a9ea9c6200750a21a80ca009",
+    "zh:6021b905d9b3cd3d7892eb04d405c6fa20112718de1d6ef7b9f1db0b0c97721a",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:9e61b8e0ccf923979cd2dc1f1140dbcb02f92248578e10c1996f560b6306317c",
+    "zh:ad6bf62cdcf531f2f92f6416822918b7ba2af298e4a0065c6baf44991fda982d",
+    "zh:b698b041ef38837753bbe5265dddbc70b76e8b8b34c5c10876e6aab0eb5eaf63",
+    "zh:bb799843c534f6a3f072a99d93a3b53ff97c58a96742be15518adf8127706784",
+    "zh:cebee0d942c37cd3b21e9050457cceb26d0a6ea886b855dab64bb67d78f863d1",
+    "zh:e061fdd1cb99e7c81fb4485b41ae000c6792d38f73f9f50aed0d3d5c2ce6dcfb",
+    "zh:eeb4943f82734946362696928336357cd1d36164907ae5905da0316a67e275e1",
+    "zh:ef09b6ad475efa9300327a30cbbe4373d817261c8e41e5b7391750b16ef4547d",
+    "zh:f01aab3881cd90b3f56da7c2a75f83da37fd03cc615fc5600a44056a7e0f9af7",
+    "zh:fcd0f724ebc4b56a499eb6c0fc602de609af18a0d578befa2f7a8df155c55550",
+  ]
+}

--- a/tf/README.md
+++ b/tf/README.md
@@ -1,0 +1,15 @@
+# AWS Solution with Terraform
+
+Inspiration is taken from [Publish to SNS with GitHub webhooks](https://www.oasys.net/posts/publish-to-sns-with-github-webhooks/) post. It arrives at an architecture very close to what I was hoping to achieve.
+
+![image](https://github.com/goodtune/webhook-testing/assets/286798/b9a4cb60-97f0-441d-87b3-07559096b81f)
+
+The main difference is that instead of "audit scripts" running as `lambda` serverless functions at the end, I want to fanout from the SNS topic onto individual SQS queues for in-house applications to subscribe to and consume from.
+
+## Configuration
+
+You will need to populate the `terraform.tfvars` file with your own values. The `terraform.tfvars.example` file is provided as a template.
+
+## Deployment
+
+This Terraform module uses the [`hashicorp/aws`](https://registry.terraform.io/providers/hashicorp/aws/latest/docs) provider - see the documentation for how to configure your AWS credentials.

--- a/tf/api_gateway.tf
+++ b/tf/api_gateway.tf
@@ -1,0 +1,81 @@
+
+resource "aws_api_gateway_rest_api" "sns-proxy" {
+  name        = "${var.name}-${var.environment}-sns-proxy"
+  description = "REST API endpoint that invokes Lambda function to verify signatures and publish to SNS topic"
+}
+
+resource "aws_api_gateway_documentation_part" "sns-ingest" {
+  location {
+    type   = "METHOD"
+    method = "POST"
+    path   = "/${aws_api_gateway_resource.sns-ingest.path_part}"
+  }
+
+  properties = jsonencode({
+    "description" : "Invokes Lambda function to verify signatures and publish to SNS topic",
+  })
+  rest_api_id = aws_api_gateway_rest_api.sns-proxy.id
+}
+
+resource "aws_api_gateway_resource" "sns-ingest" {
+  rest_api_id = aws_api_gateway_rest_api.sns-proxy.id
+  parent_id   = aws_api_gateway_rest_api.sns-proxy.root_resource_id
+  path_part   = "ingest"
+}
+
+resource "aws_api_gateway_method" "sns-ingest" {
+  rest_api_id   = aws_api_gateway_rest_api.sns-proxy.id
+  resource_id   = aws_api_gateway_resource.sns-ingest.id
+  authorization = "NONE"
+  http_method   = "POST"
+}
+
+resource "aws_api_gateway_integration" "sns-publish" {
+  rest_api_id             = aws_api_gateway_rest_api.sns-proxy.id
+  resource_id             = aws_api_gateway_resource.sns-ingest.id
+  http_method             = aws_api_gateway_method.sns-ingest.http_method
+  integration_http_method = "POST"
+  type                    = "AWS_PROXY"
+  uri                     = aws_lambda_function.lambda.invoke_arn
+}
+
+resource "aws_api_gateway_deployment" "sns-proxy" {
+  rest_api_id = aws_api_gateway_rest_api.sns-proxy.id
+  triggers = {
+    redeployment = sha1(jsonencode([
+      aws_api_gateway_resource.sns-ingest.id,
+      aws_api_gateway_method.sns-ingest.id,
+      aws_api_gateway_integration.sns-publish.id,
+    ]))
+  }
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+resource "aws_api_gateway_stage" "sns-proxy" {
+  depends_on = [aws_cloudwatch_log_group.this]
+
+  deployment_id = aws_api_gateway_deployment.sns-proxy.id
+  rest_api_id   = aws_api_gateway_rest_api.sns-proxy.id
+  stage_name    = var.environment
+  access_log_settings {
+    destination_arn = aws_cloudwatch_log_group.this.arn
+    format = jsonencode({
+      "requestId" : "$context.requestId",
+      "extendedRequestId" : "$context.extendedRequestId",
+      "ip" : "$context.identity.sourceIp",
+      "caller" : "$context.identity.caller",
+      "user" : "$context.identity.user",
+      "requestTime" : "$context.requestTime",
+      "httpMethod" : "$context.httpMethod",
+      "resourcePath" : "$context.resourcePath",
+      "status" : "$context.status",
+      "protocol" : "$context.protocol",
+      "responseLength" : "$context.responseLength"
+    })
+  }
+  tags = {
+    Environment = var.environment
+  }
+}

--- a/tf/cloudwatch.tf
+++ b/tf/cloudwatch.tf
@@ -1,0 +1,17 @@
+resource "aws_cloudwatch_log_group" "this" {
+  name              = "/service/${var.name}-${var.environment}"
+  retention_in_days = 3
+  tags = {
+    Service     = "${var.name}-${var.environment}"
+    Environment = var.environment
+  }
+}
+
+resource "aws_cloudwatch_log_group" "lambda" {
+  name              = "/aws/lambda/${var.name}-sns-publish-${var.environment}"
+  retention_in_days = 3
+  tags = {
+    Service     = "${var.name}-${var.environment}"
+    Environment = var.environment
+  }
+}

--- a/tf/iam.tf
+++ b/tf/iam.tf
@@ -1,0 +1,18 @@
+
+resource "aws_iam_role" "assume-lambda" {
+  name               = "${var.name}-${var.environment}-assume-lambda"
+  assume_role_policy = data.aws_iam_policy_document.apigw-proxy-lambda.json
+  inline_policy {
+    name   = "sns-publish"
+    policy = data.aws_iam_policy_document.sns-publish.json
+  }
+}
+
+resource "aws_iam_role" "assume-cloudwatch" {
+  name               = "${var.name}-${var.environment}-assume-cloudwatch"
+  assume_role_policy = data.aws_iam_policy_document.apigw-proxy-cloudwatch.json
+  inline_policy {
+    name   = "sns-proxy"
+    policy = data.aws_iam_policy_document.sns-publish.json
+  }
+}

--- a/tf/lambda.py
+++ b/tf/lambda.py
@@ -1,0 +1,55 @@
+import os
+import logging
+from hashlib import sha256
+from hmac import HMAC, compare_digest
+from json import dumps, loads
+
+import boto3
+import botocore
+
+LOG = logging.getLogger()
+LOG.setLevel("INFO")
+
+
+def handler(event, context):
+    LOG.info("## ENVIRONMENT VARIABLES")
+    LOG.info(os.getenv("AWS_LAMBDA_LOG_GROUP_NAME"))
+    LOG.info(os.getenv("AWS_LAMBDA_LOG_STREAM_NAME"))
+    LOG.info("## EVENT")
+    LOG.info(event)
+    if verify_signature(event["headers"], event["body"]):
+        if publish_sns({"headers": event["headers"], "body": loads(event["body"])}):
+            return respond("Success")
+        else:
+            return respond("Failed", 500)
+    return respond("Forbidden", 403)
+
+
+def respond(message, code=200):
+    return {"statusCode": code, "body": dumps({"message": message})}
+
+
+def publish_sns(message):
+    try:
+        arn = os.environ.get("TOPIC_ARN")
+        client = boto3.client("sns")
+        response = client.publish(
+            TargetArn=arn,
+            Message=dumps({"default": dumps(message)}),
+            MessageStructure="json",
+        )
+    except botocore.exceptions.ClientError as e:
+        print(f"ClientError: {e}")
+        response = {"error": e.response["Error"]["Message"]}
+    return response
+
+
+def verify_signature(headers, body):
+    try:
+        secret = os.environ.get("GITHUB_SECRET").encode("utf-8")
+        received = headers["X-Hub-Signature-256"].split("sha256=")[-1].strip()
+        expected = HMAC(secret, body.encode("utf-8"), sha256).hexdigest()
+    except (KeyError, TypeError):
+        return False
+    else:
+        return compare_digest(received, expected)

--- a/tf/lambda.tf
+++ b/tf/lambda.tf
@@ -1,0 +1,30 @@
+resource "aws_lambda_permission" "apigw_lambda" {
+  statement_id  = "AllowExecutionFromAPIGateway"
+  action        = "lambda:InvokeFunction"
+  function_name = aws_lambda_function.lambda.function_name
+  principal     = "apigateway.amazonaws.com"
+  source_arn    = "arn:aws:execute-api:${var.region}:${data.aws_caller_identity.current.account_id}:${aws_api_gateway_rest_api.sns-proxy.id}/*/${aws_api_gateway_method.sns-ingest.http_method}${aws_api_gateway_resource.sns-ingest.path}"
+}
+
+data "archive_file" "lambda" {
+  type        = "zip"
+  output_path = "lambda.zip"
+  source_file = "lambda.py"
+}
+
+resource "aws_lambda_function" "lambda" {
+  description   = "Perform signature verification of webhook and publish to SNS topic ${aws_sns_topic.this.name}"
+  filename      = data.archive_file.lambda.output_path
+  function_name = "${var.name}-sns-publish-${var.environment}"
+  handler       = "lambda.handler"
+  runtime       = "python3.10"
+  role          = aws_iam_role.assume-lambda.arn
+  publish       = true
+  environment {
+    variables = {
+      "GITHUB_SECRET" = var.secret
+      "TOPIC_ARN"     = aws_sns_topic.this.arn
+    }
+  }
+  source_code_hash = data.archive_file.lambda.output_base64sha256
+}

--- a/tf/main.tf
+++ b/tf/main.tf
@@ -1,0 +1,7 @@
+terraform {
+  required_providers {
+    aws = {}
+  }
+}
+
+data "aws_caller_identity" "current" {}

--- a/tf/outputs.tf
+++ b/tf/outputs.tf
@@ -1,0 +1,7 @@
+output "api_gateway_invoke_url" {
+  value = "${aws_api_gateway_deployment.sns-proxy.invoke_url}${var.environment}${aws_api_gateway_resource.sns-ingest.path}"
+}
+
+output "sqs_url" {
+  value = { for consumer in var.consumers : consumer => aws_sqs_queue.consumers[consumer].id }
+}

--- a/tf/policies.tf
+++ b/tf/policies.tf
@@ -1,0 +1,48 @@
+data "aws_iam_policy_document" "sns-publish" {
+  statement {
+    actions   = ["sns:Publish"]
+    resources = [aws_sns_topic.this.arn]
+    effect    = "Allow"
+  }
+}
+
+data "aws_iam_policy_document" "apigw-proxy-lambda" {
+  statement {
+    actions = ["sts:AssumeRole"]
+    principals {
+      type        = "Service"
+      identifiers = ["lambda.amazonaws.com"]
+    }
+    effect = "Allow"
+  }
+}
+
+data "aws_iam_policy_document" "apigw-proxy-cloudwatch" {
+  statement {
+    actions = ["sts:AssumeRole"]
+    principals {
+      type        = "Service"
+      identifiers = ["apigateway.amazonaws.com"]
+    }
+    effect = "Allow"
+  }
+}
+
+data "aws_iam_policy_document" "sns-publish-sqs" {
+  for_each = var.consumers
+
+  statement {
+    actions = ["sqs:SendMessage"]
+    principals {
+      type        = "Service"
+      identifiers = ["sns.amazonaws.com"]
+    }
+    effect = "Allow"
+    condition {
+      test     = "ArnEquals"
+      variable = "aws:SourceArn"
+      values   = [aws_sns_topic.this.arn]
+    }
+    resources = ["arn:aws:sqs:${var.region}:${data.aws_caller_identity.current.account_id}:${var.name}-${var.environment}-${each.value}"]
+  }
+}

--- a/tf/sns.tf
+++ b/tf/sns.tf
@@ -1,0 +1,15 @@
+resource "aws_sns_topic" "this" {
+  name         = "${var.name}-${var.environment}"
+  display_name = "Fanout topic for webhook events from ${var.name}-${var.environment}"
+  tags = {
+    Service     = "${var.name}-${var.environment}"
+    Environment = var.environment
+  }
+}
+
+resource "aws_sns_topic_subscription" "consumers" {
+  for_each  = var.consumers
+  topic_arn = aws_sns_topic.this.arn
+  protocol  = "sqs"
+  endpoint  = aws_sqs_queue.consumers[each.value].arn
+}

--- a/tf/sqs.tf
+++ b/tf/sqs.tf
@@ -1,0 +1,12 @@
+resource "aws_sqs_queue" "consumers" {
+  for_each                  = var.consumers
+  name                      = "${var.name}-${var.environment}-${each.value}"
+  message_retention_seconds = 86400
+  policy                    = data.aws_iam_policy_document.sns-publish-sqs[each.value].json
+  receive_wait_time_seconds = 20
+  tags = {
+    Service     = "${var.name}-${var.environment}"
+    Environment = var.environment
+    Region      = var.region
+  }
+}

--- a/tf/terraform.tfvars.example
+++ b/tf/terraform.tfvars.example
@@ -1,0 +1,7 @@
+consumers = [
+    "subscriber-1",
+    "subscriber-2",
+    "replay",
+]
+
+secret    = "my-secret"

--- a/tf/variables.tf
+++ b/tf/variables.tf
@@ -1,0 +1,24 @@
+variable "name" {
+  description = "The name of the project"
+  default     = "webhook-testing"
+}
+
+variable "environment" {
+  description = "The environment to deploy to"
+  default     = "dev"
+}
+
+variable "region" {
+  description = "The region to deploy to"
+  default     = "ap-southeast-2"
+}
+
+variable "secret" {
+  description = "The secret to use for the webhook"
+  sensitive   = true
+}
+
+variable "consumers" {
+  description = "The list of consumers to create queues for"
+  type        = set(string)
+}


### PR DESCRIPTION
- create an API Gateway to ingest the webhooks
- create an SNS Topic to receive the events
- create any number of SQS Queues to subscribe to SNS Topic
- create an AWS Lambda function to verify authenticity and publish to SNS Topic
